### PR TITLE
Refactor: export de debounce e ajuste visual em filtragem de DatatTables

### DIFF
--- a/src/components/Tables/DataTable/Sh3DataTable.vue
+++ b/src/components/Tables/DataTable/Sh3DataTable.vue
@@ -44,6 +44,7 @@
       :header="col.header"
       filter-header-style="background-color: white"
       reorderable-column
+      show-clear-button
       v-bind="{ ...col.props }"
     >
       <template v-if="col.type == 'tag'" #body="slotProps">

--- a/src/components/Tables/DataTable/Sh3DataTableEditable.vue
+++ b/src/components/Tables/DataTable/Sh3DataTableEditable.vue
@@ -58,6 +58,7 @@
       :sortable="col.sortable"
       filter-header-style="background-color: white"
       :pt="{ pcSortBadge: { root: 'hidden' } }"
+      show-clear-button
       v-bind="{ ...col.props }"
     >
       <template #body="{ data: row, field }">

--- a/src/components/Tables/DataTable/Sh3DataTableEditable.vue
+++ b/src/components/Tables/DataTable/Sh3DataTableEditable.vue
@@ -64,14 +64,14 @@
       <template #body="{ data: row, field }">
         <Checkbox
           v-if="col.filterType.toLowerCase() == 'boolean'"
-          v-model="row[field]"
+          v-model="row[field as string]"
           disabled
           :binary="true"
         />
         <div v-else-if="col.cellFormater">
           <component :is="col.cellFormater" v-bind="{ row, field }"></component>
         </div>
-        <div v-else>{{ getValueByPath(row, field) }}</div>
+        <div v-else>{{ getValueByPath(row, field as string) }}</div>
       </template>
       <template v-if="col.editable != false" #editor="{ data: row, field }">
         <Checkbox

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -3,3 +3,4 @@ import { customToast } from "./toast/customToast";
 export { customToast };
 export * from "./apollo";
 export * from "./echo";
+export * from "./fetch/debounce";


### PR DESCRIPTION
## Descrição

Remoção de `tailwindcss-primeui` e correção de erros de type em `components/Tables/DataTable/Sh3DataTableEditable`

### O que essa PR faz? 

export da função de debounce de `services/fetch/debounce` e ajuste visual nas filtragens de DataTable

### Issue(s) Relacionada(s)


---
## Alterações
### Tipo de mudança
> Por favor, apague as opções que não são relevantes.

- [x] Correção de bug (mudança que corrige um problema)
- [ ] Nova funcionalidade (mudança que adiciona uma nova funcionalidade)
- [ ] Atualização de documentação

### Checklist

- [x] Meu código segue as diretrizes de estilo deste projeto.
- [x] Eu realizei uma autoavaliação do meu próprio código.
- [ ] Comentei meu código, principalmente em áreas difíceis de entender.
- [ ] Fiz as alterações correspondentes na documentação.
- [x] Minhas mudanças não geram novas _warnings_.
- [ ] Adicionei testes que provam que a correção é eficaz ou que a funcionalidade funciona.
- [ ] Testes novos e existentes passam localmente com minhas alterações.

### Capturas de Tela (se aplicável)

---
## Comentários Adicionais
> Adicione qualquer outro contexto ou informação aqui que possa ser útil para os revisores.
