### PR TITLE
[Fix] Ajustes para  mandar objeto vazio em useMutation.

### DIFF
--- a/src/services/apollo/composables/useCrud.ts
+++ b/src/services/apollo/composables/useCrud.ts
@@ -10,6 +10,8 @@ import {
 } from "./types";
 import type { ApolloError } from "@apollo/client/core";
 import type { ClientDict } from "../types";
+import { Kind, type DocumentNode } from "graphql";
+const defaultcrud = <DocumentNode>{ kind: Kind.DOCUMENT, definitions: [] };
 
 /**
  *
@@ -28,21 +30,27 @@ export default function useCrud<T>(
     onDone: onDoneCreate,
     onError: onErrorCreate,
   } = provideApolloClients(clients)(() =>
-    useMutation(crud.value?.create, { clientId: clientId.value }),
+    useMutation(crud.value?.create ?? defaultcrud, {
+      clientId: clientId.value,
+    }),
   );
   const {
     mutate: mutateUpdate,
     onDone: onDoneUpdate,
     onError: onErrorUpdate,
   } = provideApolloClients(clients)(() =>
-    useMutation(crud.value?.update, { clientId: clientId.value }),
+    useMutation(crud.value?.update ?? defaultcrud, {
+      clientId: clientId.value,
+    }),
   );
   const {
     mutate: mutateDeletion,
     onDone: onDoneDeletion,
     onError: onErrorDeletion,
   } = provideApolloClients(clients)(() =>
-    useMutation(crud.value?.delete, { clientId: clientId.value }),
+    useMutation(crud.value?.delete ?? defaultcrud, {
+      clientId: clientId.value,
+    }),
   );
 
   const onDone = (event: CrudEventKey, response: object) => {


### PR DESCRIPTION
- **O que essa PR faz?**  
  *Altera o arquivo useCrud para mandar objeto vazio no useMutation devido a alteração no crudOperations que permite mandar create, update e delete undefined.*

## Tipo de mudança

- [x] Correção de bug (mudança que corrige um problema)


## Checklist:

- [x] Meu código segue as diretrizes de estilo deste projeto.
- [x] Meu código respeita os delimitadores verticais do editor de texto `80;120`.
- [x] Eu realizei uma autoavaliação do meu próprio código.
- [ ] Comentei meu código, principalmente em áreas difíceis de entender.
- [ ] Fiz as alterações correspondentes na documentação.
- [x] Minhas mudanças não geram novas _warnings_.
- [ ] Adicionei testes que provam que a correção é eficaz ou que a funcionalidade funciona.
- [ ] Testes novos e existentes passam localmente com minhas alterações.

## Frontend:

- [x] Utilizei a ferramenta de formatação e análise de código `npm run lint --fix`.
- [x] Gerei uma prévia para simular o comportamento em ambiente de produção `npm run preview`. 
- [x] Ao concluir minhas alterações, buildei meu projeto com sucesso `npm run build`. 