### PR TITLE
[FEATURE] Bloqueio de edição de formulario

### DIFF
--- a/src/components/Forms/Sh3GenericForm.vue
+++ b/src/components/Forms/Sh3GenericForm.vue
@@ -20,9 +20,16 @@
     >
       <Sh3FormButton
         v-if="options.crud.delete"
+        v-tooltip.bottom="{
+          value: options.crud.disabled ? '' : 'Excluir registro',
+          showDelay: 50,
+          hideDelay: 50,
+        }"
         name="delete"
         severity="danger"
-        container-class="col-start-1"
+        :container-class="
+          'col-start-1' + (options.crud.disabled ? ' cursor-not-allowed' : '')
+        "
         button-label="Excluir"
         :columns="1"
         outlined
@@ -33,6 +40,11 @@
       <slot name="actions"></slot>
       <Sh3FormButton
         v-if="!options.crud.edit"
+        v-tooltip.bottom="{
+          value: 'Habilitar edição',
+          showDelay: 50,
+          hideDelay: 50,
+        }"
         name="edit"
         :container-class="options.crud.cancel ? 'col-start-10' : 'col-start-11'"
         button-label="Editar"
@@ -43,6 +55,11 @@
       />
       <Sh3FormButton
         v-if="options.crud.cancel"
+        v-tooltip.bottom="{
+          value: options.crud.edit ? 'Cancelar edição' : 'Retornar',
+          showDelay: 50,
+          hideDelay: 50,
+        }"
         name="cancel"
         container-class="col-start-11"
         button-label="Cancelar"
@@ -52,9 +69,16 @@
         @click="emits('cancel', form$)"
       />
       <Sh3FormButton
+        v-tooltip.bottom="{
+          value: options.crud.save ? 'Salvar registro' : '',
+          showDelay: 50,
+          hideDelay: 50,
+        }"
         name="submit"
         severity="success"
-        container-class="col-start-12"
+        :container-class="
+          'col-start-12' + (options.crud.edit ? '' : ' cursor-not-allowed')
+        "
         button-label="Salvar"
         :columns="1"
         full
@@ -114,7 +138,7 @@ const deletion = () => {
 
 const disableAll = {
   TextElement: {
-    container: "pointer-events-none ",
+    container: "pointer-events-none",
     inputContainer: "form-bg-disabled",
   },
   TextareaElement: {

--- a/src/components/Forms/Sh3GenericForm.vue
+++ b/src/components/Forms/Sh3GenericForm.vue
@@ -6,7 +6,7 @@
     :endpoint="false"
     :disabled="!options.crud.save"
     :add-classes="{
-      ObjectElement: { container: 'bg-gray-50 p-3' },
+      ObjectElement: { container: 'bg-mercury-50 p-3' },
       ...(!options.crud.edit ? disableAll : {}),
     }"
     v-bind="$attrs"

--- a/src/components/Forms/Sh3GenericForm.vue
+++ b/src/components/Forms/Sh3GenericForm.vue
@@ -123,7 +123,11 @@ const disableAll = {
   },
   RadiogroupElement: { wrapper: "opacity-50 pointer-events-none " },
   RadioElement: {
-    wrapper: "pointer-events-none ",
+    wrapper: "pointer-events-none",
+    input: "opacity-50 form-bg-disabled",
+  },
+  CheckboxElement: {
+    container: "pointer-events-none",
     input: "opacity-50 form-bg-disabled",
   },
 };

--- a/src/components/Forms/types/index.ts
+++ b/src/components/Forms/types/index.ts
@@ -22,6 +22,8 @@ export type CrudOptions = {
   delete: boolean;
   save: boolean;
   cancel: boolean;
+  disabled?: boolean;
+  edit?: boolean;
 };
 
 export type FormOptions = {


### PR DESCRIPTION
## Descrição

Expansão do comportamento Sh3GenericForm para desabilitar os componentes do formulario com base em 2 props de `options.crud`, `edit` e `disabled`

### **Issue Relacionada:**  
  [#767](https://github.com/sh3-sistemas/departamento-pessoal/issues/767)

## Tipo de mudança

> Por favor, apague as opções que não são relevantes.

- [x] Nova funcionalidade(mudança que adiciona uma nova funcionalidade)
- [ ] Correção de bug (mudança que corrige um problema)
- [ ] Refatoração (melhoria do código fonte sem alterar comportamento externo)
- [ ] Atualização de documentação

## Checklist:

- [x] Meu código segue as diretrizes de estilo deste projeto.
- [ ] Meu código respeita os delimitadores verticais do editor de texto `80;120`.
- [x] Eu realizei uma autoavaliação do meu próprio código.
- [ ] Comentei meu código, principalmente em áreas difíceis de entender.
- [x] Fiz as alterações correspondentes na documentação.
- [x] Minhas mudanças não geram novas _warnings_.
- [ ] Adicionei testes que provam que a correção é eficaz ou que a funcionalidade funciona.
- [ ] Testes novos e existentes passam localmente com minhas alterações.

## Frontend (opcional):
> Seção opcional. Se não for relevante, retire-a por completo deste _pull request_
- [ ] Utilizei a ferramenta de formatação e análise de código `npm run lint --fix`.
- [ ] Gerei uma prévia para simular o comportamento em ambiente de produção `npm run preview`. 
- [x] Ao concluir minhas alterações, buildei meu projeto com sucesso `npm run build`. 

## Capturas de Tela (se aplicável):

![image](https://github.com/user-attachments/assets/e9e94a2e-1e38-471d-940c-ce083d920978)
![image](https://github.com/user-attachments/assets/d903be9a-f35c-4ffb-ab76-755b1ef32ca7)
