### PR TITLE
[FIX] Correção do workflow de lançamento automático

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      VERSION: "${{ github.ref_name }}"    
     steps:
       - uses: actions/checkout@v4
         with:
@@ -16,32 +18,21 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: https://registry.npmjs.org/  
       - run: npm ci 
-      - run: |
-          VERSION=${GITHUB_REF#refs/tags/}
+      - name: Atualizar versão no package.json
+        run: |          
           npm version $VERSION --no-git-tag-version
-      - run: |
+      - name: Commit e ou push da nova versão
+        run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json package-lock.json
-          git commit -m "chore(version): version bump ${GITHUB_REF#refs/tags/}"
+          git commit -m "chore(version): version bump $VERSION"
           git push origin main
-      - run: npm run build
-
-  publish-npm:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org/
-      - name: Publish to npm with dynamic tag      
-        run: |          
-          VERSION=${GITHUB_REF#refs/tags/}          
+      - run: npm run build  
+      - name: Publicar no NPM com tag dinâmica       
+        run: |    
           NPM_TAG="latest"          
           if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(.+)$ ]]; then            
             PRERELEASE="${BASH_REMATCH[1]}" 


### PR DESCRIPTION
## Descrição

> Esta PR corrige o problema de publicação incompleta da biblioteca vexis3 no NPM, onde a pasta dist não estava sendo incluída nas versões 1.0.13 e 1.0.14. Isso ocorreu porque o workflow publish-npm estava dividido em dois jobs (build e publish), que não compartilhavam arquivos entre si.

>Para resolver esse problema, foi realizada a unificação dos dois jobs em um único job que executa a construção e a publicação da biblioteca sequencialmente, garantindo que os artefatos gerados (especialmente a pasta dist) estejam disponíveis no momento da publicação.

**O que essa PR faz?**  

- Refatora o workflow publish-npm.yml, unificando os jobs build e publish em um único job.
-  Garante que a pasta dist gerada durante o processo de build esteja presente no momento da publicação no NPM.

 **Issue Relacionada:**  

Resolve [#785](https://github.com/sh3-sistemas/departamento-pessoal/issues/785)

## Tipo de mudança

- [x] Correção de bug (mudança que corrige um problema)

## Checklist:

- [x] Meu código segue as diretrizes de estilo deste projeto.
- [x] Meu código respeita os delimitadores verticais do editor de texto `80;120`.
- [x] Eu realizei uma autoavaliação do meu próprio código.
- [x] Comentei meu código, principalmente em áreas difíceis de entender.
- [x] Fiz as alterações correspondentes na documentação.
- [x] Minhas mudanças não geram novas _warnings_.
- [ ] Adicionei testes que provam que a correção é eficaz ou que a funcionalidade funciona.
- [ ] Testes novos e existentes passam localmente com minhas alterações.

