### PR TITLE
[TECH DEBIT] Adicionar breadcrumbs ao cabeçalho dos modais

### DIFF
--- a/src/components/Modals/Sh3ResponsiveModal.vue
+++ b/src/components/Modals/Sh3ResponsiveModal.vue
@@ -5,6 +5,9 @@
     :breakpoints="{ '1199px': '75vw', '575px': 'w-full' }"
     v-bind="$attrs"
   >
+    <template #header>
+      <slot name="header"></slot>
+    </template>
     <slot></slot>
   </Dialog>
 </template>


### PR DESCRIPTION
## Descrição

>Essa PR corrige a questão de posicionamento dos breadcrumbs no modal. 
Durante a execução da tarefa #642 foi solicitado que os breadcrumbs estivesse logo no topo do modal, entretanto, por falta de adaptação na Vexis, isso não foi possível em primeira instância, disponibilizando o modal sem os breadcrumbs.

Para isso, é preciso inserir a template do header no ResponsiveModal da Vexis3.

- **O que essa PR faz?**  
 * Adiciona o <template #header> no Sh3ResponsiveModal.

- **Issue Relacionada:**  

Resolve https://github.com/sh3-sistemas/departamento-pessoal/issues/667 

## Tipo de mudança
- [x] Correção de bug (mudança que corrige um problema)

## Checklist:
- [x] Meu código segue as diretrizes de estilo deste projeto.
- [x] Meu código respeita os delimitadores verticais do editor de texto `80;120`.
- [x] Eu realizei uma autoavaliação do meu próprio código.
- [ ] Comentei meu código, principalmente em áreas difíceis de entender.
- [ ] Fiz as alterações correspondentes na documentação.
- [x] Minhas mudanças não geram novas _warnings_.
- [ ] Adicionei testes que provam que a correção é eficaz ou que a funcionalidade funciona.
- [X] Testes novos e existentes passam localmente com minhas alterações.

## Frontend:
- [x] Utilizei a ferramenta de formatação e análise de código `npm run lint --fix`.
- [x] Gerei uma prévia para simular o comportamento em ambiente de produção `npm run preview`. 
- [x] Ao concluir minhas alterações, buildei meu projeto com sucesso `npm run build`. 

## Capturas de Tela (se aplicável):
Modelo esperado:
![image](https://github.com/user-attachments/assets/226805dd-2b8b-42b9-a9d1-fdd90c30be07)

Modelo atingido atualmente:
![image](https://github.com/user-attachments/assets/53782b56-5a1c-4bf3-b8ed-84b07799fc35)
![image](https://github.com/user-attachments/assets/ec1f419e-dc0c-4ff0-85e6-f6ac0f90b97e)
