### PR TITLE
[FIX]: Propriedades dinâmicas para cellFormaterEdit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vexis3",
-  "version": "1.1.0-alpha.dp.598",
+  "version": "1.0.15",
   "private": false,
   "type": "module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vexis3",
-  "version": "1.0.15",
+  "version": "1.1.0-alpha.dp.598",
   "private": false,
   "type": "module",
   "files": [

--- a/src/components/Tables/DataTable/Sh3DataTableEditable.vue
+++ b/src/components/Tables/DataTable/Sh3DataTableEditable.vue
@@ -93,7 +93,7 @@
         <div v-else-if="col.cellFormaterEdit">
           <component
             :is="col.cellFormaterEdit.component"
-            v-bind="{ ...col.cellFormaterEdit.props, row, field }"
+            v-bind="getCellFormaterEditProps(col.cellFormaterEdit, row, field)"
             @selected="
               (value: any) =>
                 updateRow(
@@ -264,4 +264,16 @@ const { filters } = useFilterTable(
   attrs.filterDisplay,
   toRef(props, "columns"),
 );
+
+const getCellFormaterEditProps = (
+  cellFormaterEdit: any,
+  row: object,
+  field: string,
+) => {
+  const baseProps = { ...cellFormaterEdit.props, row, field };
+  if (typeof cellFormaterEdit.propsFunction === "function") {
+    return { ...baseProps, ...cellFormaterEdit.propsFunction(row) };
+  }
+  return baseProps;
+};
 </script>

--- a/src/components/Tables/DataTable/Sh3DataTableEditable.vue
+++ b/src/components/Tables/DataTable/Sh3DataTableEditable.vue
@@ -265,6 +265,21 @@ const { filters } = useFilterTable(
   toRef(props, "columns"),
 );
 
+/**
+ * Gera as propriedades (props) para o componente de edição de célula (`cellFormaterEdit`).
+ *
+ * Esta função combina as propriedades base definidas em `cellFormaterEdit.props`
+ * com informações da linha (`row`) e do campo (`field`).
+ * Se `cellFormaterEdit.propsFunction` for uma função, ela será executada com a `row`
+ * e suas propriedades resultantes serão mescladas, permitindo props dinâmicas.
+ *
+ * @param cellFormaterEdit O objeto de configuração do formatador de célula para edição.
+ * Contém `component` (o componente Vue a ser renderizado), `props` (props estáticas para o componente),
+ * e opcionalmente `propsFunction` (uma função que retorna props dinâmicas baseado na linha).
+ * @param row O objeto da linha atual do DataTable que está sendo editada.
+ * @param field O nome do campo da coluna à qual a célula editável pertence.
+ * @returns Um objeto contendo todas as propriedades combinadas que serão passadas para o componente `cellFormaterEdit.component`.
+ */
 const getCellFormaterEditProps = (
   cellFormaterEdit: any,
   row: object,


### PR DESCRIPTION
## Descrição
   >A mudança visa melhorar a flexibilidade na construção de props dinâmicas, permitindo que cellFormaterEdit utilizem funções auxiliares (propsFuncion) para gerar propriedades adicionais com base no contexto da linha (row) e do campo (field).
- **O que essa PR faz?** 
Cria a função utilitária getCellFormaterEditProps(cellFormaterEdit, row, field) que:
  - Mescla as props estáticas com os dados da linha e do campo.
  - Se propsFuncion for uma função, executa propsFuncion(row) para adicionar props dinâmicas.

  #### Disponivel para teste: [1.1.0-alpha.dp.598](https://www.npmjs.com/package/vexis3/v/1.1.0-alpha.dp.598)
- **Issue Relacionada:**  

Resolve [#598](https://github.com/sh3-sistemas/departamento-pessoal/issues/598)

## Tipo de mudança

- [X] Correção de bug (mudança que corrige um problema)

## Checklist:

- [x] Meu código segue as diretrizes de estilo deste projeto.
- [x] Meu código respeita os delimitadores verticais do editor de texto `80;120`.
- [x] Eu realizei uma autoavaliação do meu próprio código.
- [ ] Comentei meu código, principalmente em áreas difíceis de entender.
- [ ] Fiz as alterações correspondentes na documentação.
- [x] Minhas mudanças não geram novas _warnings_.
- [ ] Adicionei testes que provam que a correção é eficaz ou que a funcionalidade funciona.
- [ ] Testes novos e existentes passam localmente com minhas alterações.

## Frontend :
- [x] Utilizei a ferramenta de formatação e análise de código `npm run lint --fix`.
- [x] Gerei uma prévia para simular o comportamento em ambiente de produção `npm run preview`. 
- [x] Ao concluir minhas alterações, buildei meu projeto com sucesso `npm run build`. 

