### PR TITLE
[FIX] Ajuste de exibição TableInputSelect e TableInputMultiSelect em modo de visualização 

### DIFF
--- a/src/components/Tables/DataTable/fragments/inputs/TableInputMultiSelect.vue
+++ b/src/components/Tables/DataTable/fragments/inputs/TableInputMultiSelect.vue
@@ -1,15 +1,10 @@
 <template>
-  <span v-if="!edit">
-    <Tag
-      v-if="preset == 'multiSelectTag'"
-      v-bind="tagOption"
-      :value="tagOption.name"
-      :pt-options="{ mergeProps: true }"
-    />
-    <span v-else>
-      {{ value }}
-    </span>
-  </span>
+  <Tag
+    v-if="!edit && preset == 'multiSelectTag'"
+    v-bind="tagOption"
+    :value="tagOption.name"
+    :pt-options="{ mergeProps: true }"
+  />
   <MultiSelect
     v-else
     :default-value="value"
@@ -17,6 +12,8 @@
     :option-label="preset ? presets[preset].optionLabel : undefined"
     :option-value="preset ? presets[preset].optionValue : undefined"
     :pt-options="{ mergeProps: true }"
+    :pt="edit ? {} : nonEditPT"
+    :disabled="!edit"
     :max-selected-labels="1"
     v-bind="$attrs"
     @value-change="(value: any) => $parent?.$emit('change', value)"
@@ -52,4 +49,10 @@ const tagOption = computed(() => {
     ? props.options.find((x) => x.value == props.value)
     : undefined;
 });
+
+const nonEditPT = {
+  root: "!border-none !shadow-none !bg-transparent !opacity-100",
+  label: "!text-inherit",
+  dropdown: "hidden",
+};
 </script>

--- a/src/components/Tables/DataTable/fragments/inputs/TableInputSelect.vue
+++ b/src/components/Tables/DataTable/fragments/inputs/TableInputSelect.vue
@@ -1,15 +1,10 @@
 <template>
-  <span v-if="!edit">
-    <Tag
-      v-if="preset == 'selectTag'"
-      v-bind="tagOption"
-      :value="tagOption?.name"
-      :pt-options="{ mergeProps: true }"
-    />
-    <span v-else>
-      {{ value }}
-    </span>
-  </span>
+  <Tag
+    v-if="!edit && preset == 'selectTag'"
+    v-bind="tagOption"
+    :value="tagOption?.name"
+    :pt-options="{ mergeProps: true }"
+  />
   <Select
     v-else
     :default-value="value"
@@ -17,6 +12,8 @@
     :option-label="preset ? presets[preset].optionLabel : undefined"
     :option-value="preset ? presets[preset].optionValue : undefined"
     :pt-options="{ mergeProps: true }"
+    :pt="edit ? {} : nonEditPT"
+    :disabled="!edit"
     v-bind="$attrs"
     @value-change="(value: any) => $parent?.$emit('change', value)"
   >
@@ -51,4 +48,10 @@ const tagOption = computed(() => {
     ? props.options.find((x) => x.value == props.value)
     : undefined;
 });
+
+const nonEditPT = {
+  root: "!border-none !shadow-none !bg-transparent !opacity-100",
+  label: "!text-inherit",
+  dropdown: "hidden",
+};
 </script>


### PR DESCRIPTION
## Descrição

- **O que essa PR faz?** 
Correção em `TableInputSelect` e `TableInputMultiSelect` para exibir de maneira consistente dos mesmos dados no modo de visualização e edição quando é feito o uso do props `optionLabel`.

- **Issue Relacionada:**  

## Tipo de mudança

> Por favor, apague as opções que não são relevantes.

- [ ] Nova funcionalidade(mudança que adiciona uma nova funcionalidade)
- [x] Correção de bug (mudança que corrige um problema)
- [ ] Refatoração (melhoria do código fonte sem alterar comportamento externo)
- [ ] Atualização de documentação

## Checklist:

- [x] Meu código segue as diretrizes de estilo deste projeto.
- [ ] Meu código respeita os delimitadores verticais do editor de texto `80;120`.
- [x] Eu realizei uma autoavaliação do meu próprio código.
- [ ] Comentei meu código, principalmente em áreas difíceis de entender.
- [ ] Fiz as alterações correspondentes na documentação.
- [x] Minhas mudanças não geram novas _warnings_.
- [ ] Adicionei testes que provam que a correção é eficaz ou que a funcionalidade funciona.
- [ ] Testes novos e existentes passam localmente com minhas alterações.

## Frontend (opcional):
> Seção opcional. Se não for relevante, retire-a por completo deste _pull request_
- [x] Utilizei a ferramenta de formatação e análise de código `npm run lint --fix`.
- [x] Gerei uma prévia para simular o comportamento em ambiente de produção `npm run preview`. 
- [x] Ao concluir minhas alterações, buildei meu projeto com sucesso `npm run build`. 

## Capturas de Tela (se aplicável):
Antes:
<img width="1318" height="318" alt="image" src="https://github.com/user-attachments/assets/004791df-b5a8-4c61-a5b6-788204493c13" />

Depois
<img width="1388" height="342" alt="image" src="https://github.com/user-attachments/assets/29b6ac24-d194-4579-af6d-5a4667cfdbd0" />


## Comentários Adicionais

*Adicione qualquer outro contexto ou informação aqui que possa ser útil para os revisores.*