### PR TITLE
[FEATURE] Toast amarelo para mensagem de warning

### DIFF
--- a/src/services/apollo/error/crud.ts
+++ b/src/services/apollo/error/crud.ts
@@ -33,7 +33,11 @@ export const crudError = (error: ErrorResponse) => {
     );
 
     validations?.forEach((validation) => {
-      toast.error(validation);
+      if (validation.startsWith("[warning]")) {
+        toast.warning(validation.replace("[warning]", "").trim());
+      } else {
+        toast.error(validation);
+      }
     });
   });
 };

--- a/src/services/toast/notification/types.ts
+++ b/src/services/toast/notification/types.ts
@@ -2,7 +2,7 @@ import { POSITION } from "vue-toastification";
 
 export const toastOptions = {
   position: POSITION.BOTTOM_RIGHT,
-  timeout: 4000,
+  timeout: 10000,
   closeButton: false,
   hideProgressBar: true,
   icon: false,


### PR DESCRIPTION
## Descrição

> Essa PR ajusta a forma como mensagens de validação são exibidas para o usuário, diferenciando avisos de erros. Anteriormente, todas as mensagens eram apresentadas como toast vermelho (erro), mesmo nos casos em que não havia falha de cadastro, apenas um alerta.

- **O que essa PR faz?**  
1- Implementa a exibição de toast amarelo quando a mensagem de validação vier marcada como aviso ([warning]).
2- Aumenta o tempo de exibição dos toasts para garantir que o usuário tenha tempo suficiente de visualizar o aviso/erro.

- **Issue Relacionada:**  

Resolve [#953](https://github.com/sh3-sistemas/departamento-pessoal/issues/953)

## Tipo de mudança

- [x] Nova funcionalidade(mudança que adiciona uma nova funcionalidade)

## Checklist:

- [x] Meu código segue as diretrizes de estilo deste projeto.
- [x] Meu código respeita os delimitadores verticais do editor de texto `80;120`.
- [x] Eu realizei uma autoavaliação do meu próprio código.
- [ ] Comentei meu código, principalmente em áreas difíceis de entender.
- [ ] Fiz as alterações correspondentes na documentação.
- [x] Minhas mudanças não geram novas _warnings_.
- [ ] Adicionei testes que provam que a correção é eficaz ou que a funcionalidade funciona.
- [ ] Testes novos e existentes passam localmente com minhas alterações.

## Frontend:
- [x] Utilizei a ferramenta de formatação e análise de código `npm run lint --fix`.
- [x] Gerei uma prévia para simular o comportamento em ambiente de produção `npm run preview`. 
- [x] Ao concluir minhas alterações, buildei meu projeto com sucesso `npm run build`. 

