### PR TITLE
[FIX] correção da warning de useQuery()

### DIFF
--- a/src/components/Tables/types/index.ts
+++ b/src/components/Tables/types/index.ts
@@ -1,7 +1,10 @@
 import type { ApolloQueryResult, OperationVariables } from "@apollo/client";
-import type { DocumentParameter } from "@vue/apollo-composable/dist/useQuery.js";
+import type {
+  DocumentParameter,
+  VariablesParameter,
+} from "@vue/apollo-composable/dist/useQuery.js";
 
-export type FetchOptions = {
+export type FetchPaginationOptions = {
   /**
    * O identificador único do cliente que está realizando a operação de busca.
    */
@@ -25,32 +28,29 @@ export type FetchOptions = {
   loadOnMount?: boolean;
 };
 
-export type Fetch<T> = {
+export type FetchPagination<
+  TData,
+  TVariables extends OperationVariables = OperationVariables,
+> = {
   /**
    * Objeto que contém os critérios da consulta principal.
    * Aqui podem estar condições como chaves de pesquisa, datas, etc.
    */
-  query: DocumentParameter<T, OperationVariables>;
+  query: DocumentParameter<TData, TVariables>;
 
   /**
    * Um objeto que define filtros adicionais aplicados à busca.
    * Pode ser `null` caso não existam filtros adicionais.
    */
-  filterQuery: object | null;
-
-  /**
-   * O número máximo de itens que devem ser retornados na busca.
-   * Pode sobrescrever o valor de `limit` em `FetchOptions`.
-   */
-  limit: number;
+  filterQuery: VariablesParameter<TVariables> | null;
 
   /**
    * Um objeto que contém as opções adicionais para a busca, como clientId, paginação, etc.
    */
-  options: FetchOptions;
+  options: FetchPaginationOptions;
 
   /**
    * Função de callback para o retorno do resultado da query
    */
-  onDone?: (result: ApolloQueryResult<T>) => void;
+  onDone?: (result: ApolloQueryResult<TData>) => void;
 };

--- a/src/services/apollo/composables/types/index.ts
+++ b/src/services/apollo/composables/types/index.ts
@@ -49,12 +49,12 @@ export type UseCrudEmits = (
 ) => void;
 
 export type FetchParams<
-  TResult = unknown,
+  TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
 > = {
-  query: DocumentParameter<TResult, TVariables>;
+  query: DocumentParameter<TData, TVariables>;
   variables: VariablesParameter<TVariables>;
-  options: OptionsParameter<TResult, TVariables>;
+  options: OptionsParameter<TData, TVariables>;
 };
 
 export type UseFetchState<T> = Omit<


### PR DESCRIPTION
## Descrição

### **O que essa PR faz?** 
Corrige a warning de `useQuery()` exibida ao se utilizar o `useFetch()` fora da etapa de montagem do componente (ex.: `useSearch()`). 

##### **Explicação do problema:**
O _warning_ `useQuery() is called outside of an active effect scope` era causado por uma assincronia. Isso porque o Vue, através do `@vue/apollo-composable`, espera que o `useQuery` seja chamado **durante a fase de `setup` de um componente**. Nesse momento,  ele consegue registrar a query corretamente no ciclo de vida do componente, sabendo quando iniciá-la e quando "limpá-la" se o componente for destruído, evitando vazamentos de memória.

A abordagem inicial e problemática era chamar `useQuery` **dentro** da função `fetch`. Quando um botão era clicado, a função `fetch` era executada após o fim da fase de `setup`, acarretando a warning sobre o `useQuery`.

#### **Correção:**
Após a refatoração do `useFetch()`, o `useQuery()` é chamado durante a fase de setup. A sua função de `fetch`, por sua vez, fica condicionada à reatividade do próprio composable. Assim, ela se torna disponível para a execução em outros momentos , mediante um gatilho. 

### **Issue Relacionada:**  
- Resolve #53 

## Tipo de mudança
> Por favor, apague as opções que não são relevantes.

- [ ] Nova funcionalidade(mudança que adiciona uma nova funcionalidade)
- [x] Correção de bug (mudança que corrige um problema)
- [ ] Refatoração (melhoria do código fonte sem alterar comportamento externo)
- [ ] Atualização de documentação

## Checklist:
- [x] Meu código segue as diretrizes de estilo deste projeto.
- [ ] Meu código respeita os delimitadores verticais do editor de texto `80;120`.
- [x] Eu realizei uma autoavaliação do meu próprio código.
- [x] Comentei meu código, principalmente em áreas difíceis de entender.
- [ ] Fiz as alterações correspondentes na documentação.
- [x] Minhas mudanças não geram novas _warnings_.
- [ ] Adicionei testes que provam que a correção é eficaz ou que a funcionalidade funciona.
- [ ] Testes novos e existentes passam localmente com minhas alterações.

## Frontend (opcional):
> Seção opcional. Se não for relevante, retire-a por completo deste _pull request_
- [x] Utilizei a ferramenta de formatação e análise de código `npm run lint --fix`.
- [x] Gerei uma prévia para simular o comportamento em ambiente de produção `npm run preview`. 
- [x] Ao concluir minhas alterações, buildei meu projeto com sucesso `npm run build`. 

## Capturas de Tela (se aplicável):
Antes:
<img width="1913" height="953" alt="image" src="https://github.com/user-attachments/assets/0bf0f5ee-bc16-49f8-8d56-7d6461e1008e" />

Depois:
<img width="1913" height="953" alt="image" src="https://github.com/user-attachments/assets/3db1b693-c9b6-4523-bb5d-f02510679c05" />


## Comentários Adicionais
*Adicione qualquer outro contexto ou informação aqui que possa ser útil para os revisores.*